### PR TITLE
Update to 2.10.10:

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "2.10.7" %}
+{% set version = "2.10.10" %}
 
 package:
   name: coin-or-cbc-meta
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://github.com/coin-or/Cbc/archive/releases/{{ version }}.tar.gz
-  sha256: 5aa5490e2bc39c3c03f3636c9bca459cb3f8f365e0280fd0c4759ce3119e5b19
+  sha256: f394efecccc40a51bf79fba2c2af0bc92561f3e6b8b6e4c6e36d5e70986f734f
 
 build:
   number: 0


### PR DESCRIPTION
 - version updated.
 - sha256 updated.
 - dev_url: https://github.com/coin-or/Cbc/tree/releases/2.10.10
 - Jira ticket: https://anaconda.atlassian.net/browse/PKG-2535